### PR TITLE
Expiring values example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,10 +75,10 @@ Setting values that expire
 ::
 
     seconds = 5;
-    locache.set("expiring_key", "expiring_value", seconds);
+    locache.set("key", "value", seconds);
 
     // After 5 seconds this will return null.
-    locache.get("expiring_key");
+    locache.get("key");
 
 
 Incrementing and decremening? Sure.

--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ Setting values that expire
 ::
 
     seconds = 5;
-    locache.get("expiring_key", "expiring_value", seconds);
+    locache.set("expiring_key", "expiring_value", seconds);
 
     // After 5 seconds this will return null.
     locache.get("expiring_key");


### PR DESCRIPTION
There is an error in the expiring values example where the "set" call is a "get". I fixed it.

I've also changed key and value in the example to make it more obvious, but that's a minor and personal issue.
