### PR TITLE
Remove expireKey when no timeout is given

### DIFF
--- a/locache.js
+++ b/locache.js
@@ -335,7 +335,6 @@
         }
         else {
             // Remove the expire key, if no timeout is set
-            var expireKey = this.expirekey(key);
             this.storage.remove(expireKey);
         }
 

--- a/locache.js
+++ b/locache.js
@@ -333,6 +333,11 @@
             var ms = seconds * 1000;
             this.storage.set(expireKey, _currentTime() + ms);
         }
+        else {
+            // Remove the expire key, if no timeout is set
+            var expireKey = this.expirekey(key);
+            this.storage.remove(expireKey);
+        }
 
         // For the value, always convert it into a JSON object. THis means
         // that we can safely store many types of objects. They still need to

--- a/tests/specs/local.js
+++ b/tests/specs/local.js
@@ -58,6 +58,30 @@ describe("localStorage:", function () {
         expect(typeof this.cache.get("my_number")).toBe("number");
     });
 
+    it("should get a cached item after the timeout was omitted", function () {
+        // set with timeout
+        this.cache.set("item", "a", 1);
+        // remove the timeout
+        this.cache.set("item", "a");
+        
+        var callCount = 0;
+        
+        // wait 1.2 seconds until the cache is expired
+        setTimeout(function () {
+            callCount++;
+        }, 1200);
+        
+        // wait 1.3 seconds to retrieve the item from the cache
+        setTimeout(function () {
+            expect(that.cache.get("item")).toBe("a");
+            callCount++;
+        }, 1300);
+        
+         waitsFor(function () {
+            return callCount === 2;
+        });
+    });
+
     it("should test setting a value with an expire time", function () {
 
         var key = "will_expire", value = "value";


### PR DESCRIPTION
Hi, you have a small bug in locache.
Example:

``` js
locache.set("test", "abc", 10) // timeout 10 sec
locache.set("test", "abc") // no timeout, should always be accessible
// wait 15 seconds
locache.get("test") //=> null
```

I think the right behaviour should be to remove any expire settings if I omit the timeout.

Thanks
