### PR TITLE
Hack to fix font rendering during animation in Chrome on Windows.

### DIFF
--- a/gh-pages/css/style.css
+++ b/gh-pages/css/style.css
@@ -160,6 +160,7 @@ body {
   -moz-box-shadow: 0.3em 0.3em 0.6em #aaa;
   -webkit-box-shadow: 0.3em 0.3em 0.6em #aaa;
   box-shadow: 2px 2px 8px #aaa;
+  -webkit-backface-visibility: hidden;
 }
 
 .block_list {


### PR DESCRIPTION
When viewing http://locachejs.org on Chrome 31.0 on Windows, the font jitters during the rotation animations.  This is adds `-webkit-backface-visibility: hidden` to the CSS to fix it.

See: http://stackoverflow.com/a/6898097/497934
